### PR TITLE
Fix 404 on refresh by switching to HashRouter

### DIFF
--- a/web-dev/src/components/components.jsx
+++ b/web-dev/src/components/components.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-    BrowserRouter as Router,
+    HashRouter as Router,
     Navigate,
     Routes,
     Route,


### PR DESCRIPTION
## Summary
- resolve Vercel 404 errors by using `HashRouter`

## Testing
- `npm install`
- `npm run build`
- `npm run lint` *(fails: React is defined but never used etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840542a03c083328a4cfcb27180b479