### PR TITLE
Fix timezone when fetching today's menu

### DIFF
--- a/web-dev/src/api/menu.js
+++ b/web-dev/src/api/menu.js
@@ -3,7 +3,13 @@ import Parse from 'parse';
 export const getAvailableDiningHalls = async () => {
   try {
     const today = new Date();
-    const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+    const options = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'America/New_York',
+    };
     const formattedDate = today.toLocaleDateString('en-US', options);
     
     const query = new Parse.Query('Menu');

--- a/web-dev/src/components/Pages/DiningHall.jsx
+++ b/web-dev/src/components/Pages/DiningHall.jsx
@@ -17,7 +17,13 @@ const DiningHall = () => {
   useEffect(() => {
     const fetchMeals = async () => {
       const today = new Date();
-      const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+      const options = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'America/New_York',
+      };
       const formattedDate = today.toLocaleDateString('en-US', options);
       setCurrentDate(formattedDate);
 

--- a/web-dev/src/components/Pages/Meal.jsx
+++ b/web-dev/src/components/Pages/Meal.jsx
@@ -21,7 +21,13 @@ const Meal = () => {
   useEffect(() => {
     const fetchStations = async () => {
       const today = new Date();
-      const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+      const options = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'America/New_York',
+      };
       const formattedDate = today.toLocaleDateString('en-US', options);
       setCurrentDate(formattedDate);
 


### PR DESCRIPTION
## Summary
- ensure the frontend queries Back4App using Eastern timezone

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68459f26540c833293cbff13f8ab7782