### PR TITLE
Fix timezone when fetching today's menu

### DIFF
--- a/web-dev/src/api/menu.js
+++ b/web-dev/src/api/menu.js
@@ -3,21 +3,19 @@ import Parse from 'parse';
 export const getAvailableDiningHalls = async () => {
   try {
     const today = new Date();
-    const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+    const options = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'America/New_York',
+    };
     const formattedDate = today.toLocaleDateString('en-US', options);
     
     const query = new Parse.Query('Menu');
     query.equalTo('date', formattedDate);
-    // Fetch all records for the date to ensure all dining halls are accounted for
-    // Parse's default limit of 100 results can exclude halls when one hall has
-    // more than 100 menu items.
-    query.limit(1000);
-    // Only request the diningHall field to minimize data transfer
-    query.select('diningHall');
-    const results = await query.find();
-    
-    // Get unique dining halls
-    const diningHalls = [...new Set(results.map(result => result.get('diningHall')))];
+    // Use the distinct query to get unique dining halls directly
+    const diningHalls = await query.distinct('diningHall');
     return diningHalls;
   } catch (error) {
     console.error('Error fetching available dining halls:', error);

--- a/web-dev/src/components/Pages/DiningHall.jsx
+++ b/web-dev/src/components/Pages/DiningHall.jsx
@@ -17,7 +17,13 @@ const DiningHall = () => {
   useEffect(() => {
     const fetchMeals = async () => {
       const today = new Date();
-      const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+      const options = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'America/New_York',
+      };
       const formattedDate = today.toLocaleDateString('en-US', options);
       setCurrentDate(formattedDate);
 

--- a/web-dev/src/components/Pages/Meal.jsx
+++ b/web-dev/src/components/Pages/Meal.jsx
@@ -21,7 +21,13 @@ const Meal = () => {
   useEffect(() => {
     const fetchStations = async () => {
       const today = new Date();
-      const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+      const options = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'America/New_York',
+      };
       const formattedDate = today.toLocaleDateString('en-US', options);
       setCurrentDate(formattedDate);
 


### PR DESCRIPTION
## Summary
- ensure the frontend queries Back4App using Eastern timezone
- improve available dining hall query to use distinct

## Testing
- `npm run lint` *(fails: multiple lint errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68459f26540c833293cbff13f8ab7782